### PR TITLE
[UI] Warn about unsaved progress

### DIFF
--- a/components/UI/labeledEditor.tsx
+++ b/components/UI/labeledEditor.tsx
@@ -1,16 +1,8 @@
 import React from "react";
 import Editor, { OnMount } from "@monaco-editor/react";
-import {
-  Box,
-  Flex,
-  Heading,
-  Spacer,
-  Text,
-  useMergeRefs,
-} from "@chakra-ui/react";
+import { Box, Flex, Heading, Spacer, Text } from "@chakra-ui/react";
 
 import { monospaceFontFamily } from "./constants";
-import { parentPort } from "worker_threads";
 
 type LabeledEditorProps = {
   height?: string;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -135,6 +135,10 @@ const Home: NextPage = () => {
   }
 
   function setCurrentStageIdx(idx: number) {
+    if (idx == currentStageIdx) {
+      return;
+    }
+    
     // make sure nothing is running
     if (runStatus) {
       toast({

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -138,7 +138,7 @@ const Home: NextPage = () => {
     if (idx == currentStageIdx) {
       return;
     }
-    
+
     // make sure nothing is running
     if (runStatus) {
       toast({
@@ -221,19 +221,19 @@ const Home: NextPage = () => {
 
   // Update the preset selection of the current stage.
   function setPresetSelection(selection: string) {
+    if (isEditorDirty(true)) {
+      // Check with the user first. If dialogs are disabled, this will always return false.
+      if (
+        !window.confirm(
+          "Do you want the new preset to override your existing code?"
+        )
+      ) {
+        return;
+      }
+    }
+
     updateState((oldState) => {
       let newStage = { ...oldState };
-      if (isEditorDirty(true)) {
-        // Check with the user first. If dialogs are disabled, this will always return false.
-        if (
-          !window.confirm(
-            "Do you want the new preset to override your existing code?"
-          )
-        ) {
-          return oldState;
-        }
-      }
-
       const presetProps = getPreset(selection);
       newStage.preset = selection;
       newStage.additionalRunArgs = presetProps.getDefaultAdditionalRunArgs();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,7 +33,6 @@ import NavBar from "../components/UI/navbar";
 import WasmCompiler from "../components/WasmCompiler";
 import { RunStatus } from "../components/Utils/RunStatus";
 import { PlaygroundPreset } from "../components/Presets/PlaygroundPreset";
-import { MdOutlineSdStorage } from "react-icons/md";
 
 // Stores the configuration of a particular stage.
 class StageState {


### PR DESCRIPTION
Warn user about unsaved progress. Can happen in two ways:
- User modifies code and attempts to select another preset.
- User modifies code and attempts to leave the page.