### PR TITLE
[ci/cd] Fix production deployment workflow

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -2,10 +2,7 @@ name: Build, Test, Deploy
 # This action will automatically build, test, and deploy to either preview or production.
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
 
 concurrency:
   group: build-test-deploy-${{ github.ref }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Configure Node version
-      - uses: actions/setup-node@v3
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -124,7 +124,7 @@ jobs:
       
       - name: Push site to Cloudflare Pages
         id: publish-to-cf-pages
-        run: ./scripts/publish_to_cf_pages.sh ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} ${{ github.head_ref }} $GITHUB_OUTPUT
+        run: ./scripts/publish_to_cf_pages.sh ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} ${{ github.ref_name }} $GITHUB_OUTPUT
       
       - name: Mark end of deployment
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -2,7 +2,10 @@ name: Build, Test, Deploy
 # This action will automatically build, test, and deploy to either preview or production.
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
 
 concurrency:
   group: build-test-deploy-${{ github.ref }}

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -120,7 +120,7 @@ jobs:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ github.ref == 'refs/heads/main' && 'production' || 'pull request' }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref_name }}
       
       - name: Push site to Cloudflare Pages
         id: publish-to-cf-pages

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -29,6 +29,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+      
+      - name: Configure Node version
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -120,11 +120,11 @@ jobs:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ github.ref == 'refs/heads/main' && 'production' || 'pull request' }}
-          ref: ${{ github.ref_name }}
+          ref: ${{ github.head_ref || github.ref_name }}
       
       - name: Push site to Cloudflare Pages
         id: publish-to-cf-pages
-        run: ./scripts/publish_to_cf_pages.sh ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} ${{ github.ref_name }} $GITHUB_OUTPUT
+        run: ./scripts/publish_to_cf_pages.sh ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} ${{ github.head_ref || github.ref_name }} $GITHUB_OUTPUT
       
       - name: Mark end of deployment
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure Node version
-      - uses: actions/setup-node@v3
+        uses: actions/setup-node@v3
         with:
           node-version: '18.x'
 

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -43,4 +43,4 @@ jobs:
         run: npm install
 
       - name: Run deployment cleanup script
-        run: npx ts-node ./scripts/delete_preview_deployments.ts ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} mlir-playground-direct ${{ github.ref_name }}
+        run: npx ts-node ./scripts/delete_preview_deployments.ts ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} mlir-playground-direct ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Configure Node version
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+
       - name: Install npm dependencies
         run: npm install
 

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -43,4 +43,4 @@ jobs:
         run: npm install
 
       - name: Run deployment cleanup script
-        run: npx ts-node ./scripts/delete_preview_deployments.ts ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} mlir-playground-direct ${{ github.head_ref }}
+        run: npx ts-node ./scripts/delete_preview_deployments.ts ${{ secrets.CLOUDFLARE_API_TOKEN }} ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} mlir-playground-direct ${{ github.ref_name }}

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -3,6 +3,8 @@ name: Cleanup Previews
 
 on:
   pull_request:
+    types:
+      - closed
 
 concurrency:
   group: cleanup-previews-${{ github.ref }}

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -3,8 +3,6 @@ name: Cleanup Previews
 
 on:
   pull_request:
-    types:
-      - closed
 
 concurrency:
   group: cleanup-previews-${{ github.ref }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "mlir-playground",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "postinstall": "./prepare.sh",
     "dev": "next dev",

--- a/scripts/delete_preview_deployments.ts
+++ b/scripts/delete_preview_deployments.ts
@@ -90,7 +90,6 @@ async function deleteDeployments(deploymentIds: Array<string>) {
       console.log("Deleted: " + deploymentId);
       successCount++;
     }
-    break;
   }
 
   console.log("Successfully deleted %d deployments.", successCount);


### PR DESCRIPTION
The deployment workflow was using `github.head_ref`, which is not available for push-triggered workflows. Use a different way to access a branch name for labelling deployments.
Also fix the node version issue impacting the preview cleanup script.