### PR TITLE
Check for incompatible local environment

### DIFF
--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -112,7 +112,8 @@ const ShareButton = (props: ShareButtonProps) => {
 };
 
 type LocalEnvironmentStatusProps = {
-  envVersion: string; // empty string means not ready
+  envVersion: string;
+  envStatus: "Pending" | "Outdated" | "Ready";
   envPopoverOpen: boolean;
   setEnvPopoverOpen: (isOpen: boolean) => void;
   initiateEnvDownload: () => Promise<boolean>;
@@ -131,7 +132,8 @@ This will incur a download of ~100MB once.`;
     });
   };
 
-  const envReady = !!props.envVersion;
+  const envCached = props.envStatus != "Pending";
+  const envReady = props.envStatus == "Ready";
 
   return (
     <Popover
@@ -149,7 +151,7 @@ This will incur a download of ~100MB once.`;
           backgroundColor={envReady ? "green.200" : "gray.200"}
           onClick={() => props.setEnvPopoverOpen(true)}
         >
-          {envReady ? "Ready" : "Pending"}
+          {props.envStatus}
         </Button>
       </PopoverTrigger>
       <PopoverContent>
@@ -160,7 +162,7 @@ This will incur a download of ~100MB once.`;
         <PopoverCloseButton />
         <PopoverBody style={{ whiteSpace: "pre-wrap" }}>
           <p>{popoverMessage}</p>
-          {envReady && <i>Local Version: {props.envVersion}</i>}
+          {envCached && <i>Local Version: {props.envVersion}</i>}
         </PopoverBody>
         <PopoverFooter d="flex" justifyContent="flex-end">
           <Button
@@ -169,7 +171,7 @@ This will incur a download of ~100MB once.`;
             isLoading={downloadInProgress}
             onClick={onDownloadButtonClick}
           >
-            {envReady ? "Downloaded" : "Download"}
+            {envReady ? "Downloaded" : envCached ? "Update" : "Download"}
           </Button>
         </PopoverFooter>
       </PopoverContent>

--- a/components/UI/navbar.tsx
+++ b/components/UI/navbar.tsx
@@ -111,9 +111,15 @@ const ShareButton = (props: ShareButtonProps) => {
   );
 };
 
+export enum LocalEnvironmentCachingStatus {
+  PENDING = "Pending",
+  OUTDATED = "Outdated",
+  READY = "Ready",
+}
+
 type LocalEnvironmentStatusProps = {
   envVersion: string;
-  envStatus: "Pending" | "Outdated" | "Ready";
+  envStatus: LocalEnvironmentCachingStatus;
   envPopoverOpen: boolean;
   setEnvPopoverOpen: (isOpen: boolean) => void;
   initiateEnvDownload: () => Promise<boolean>;
@@ -132,8 +138,8 @@ This will incur a download of ~100MB once.`;
     });
   };
 
-  const envCached = props.envStatus != "Pending";
-  const envReady = props.envStatus == "Ready";
+  const envCached = props.envStatus != LocalEnvironmentCachingStatus.PENDING;
+  const envReady = props.envStatus == LocalEnvironmentCachingStatus.READY;
 
   return (
     <Popover

--- a/components/Utils/Events.ts
+++ b/components/Utils/Events.ts
@@ -1,4 +1,7 @@
-type EnvDownloadStart = { kind: "EnvDownloadStart"; props: never };
+type EnvDownloadStart = {
+  kind: "EnvDownloadStart";
+  props: { isUpdate: boolean };
+};
 type EnvDownloadDone = { kind: "EnvDownloadDone"; props: { success: boolean } };
 type RunStart = { kind: "RunStart"; props: { preset: string } };
 type RunEnd = { kind: "RunEnd"; props: never };

--- a/components/WasmCompiler/index.ts
+++ b/components/WasmCompiler/index.ts
@@ -1,7 +1,4 @@
 import {
-  del as idb_del,
-  get as idb_get,
-  set as idb_set,
   delMany as idb_delMany,
   getMany as idb_getMany,
   setMany as idb_setMany,

--- a/components/WasmCompiler/index.ts
+++ b/components/WasmCompiler/index.ts
@@ -1,4 +1,11 @@
-import { del as idb_del, get as idb_get, set as idb_set } from "idb-keyval";
+import {
+  del as idb_del,
+  get as idb_get,
+  set as idb_set,
+  delMany as idb_delMany,
+  getMany as idb_getMany,
+  setMany as idb_setMany,
+} from "idb-keyval";
 
 import WasmFetcher from "../WasmFetcher";
 
@@ -6,6 +13,7 @@ import {
   LLVM_VERSION,
   SYSTEM_LIB_NAMES,
   LLVM_LIB_FILES,
+  LLVM_PACKAGE_CHECKSUM,
 } from "./wasm/constants.js";
 import ClangModule from "./wasm/clang.mjs";
 import LldModule from "./wasm/wasm-ld.mjs";
@@ -13,6 +21,7 @@ import TemplateModule from "./template.js";
 
 import { RunStatus, RunStatusListener } from "../Utils/RunStatus";
 
+const LLVM_PACKAGE_CHECKSUM_METADATA_KEY = "llvm_package_checksum";
 const LLVM_VERSION_METADATA_KEY = "llvm_version";
 const CLANG_DATA_FILE = "onlyincludes.data";
 const CLANG_WASM_FILE = "clang.wasm";
@@ -292,32 +301,37 @@ class WasmCompiler {
     return Promise.all(fetches).then(
       (results) => {
         // set metadata version
-        idb_set(LLVM_VERSION_METADATA_KEY, LLVM_VERSION);
+        idb_setMany([
+          [LLVM_VERSION_METADATA_KEY, LLVM_VERSION],
+          [LLVM_PACKAGE_CHECKSUM_METADATA_KEY, LLVM_PACKAGE_CHECKSUM],
+        ]);
         return true;
       },
       (err) => {
-        idb_del(LLVM_VERSION_METADATA_KEY);
+        idb_delMany([
+          LLVM_VERSION_METADATA_KEY,
+          LLVM_PACKAGE_CHECKSUM_METADATA_KEY,
+        ]);
         return false;
       }
     );
   }
 
-  // If data files are cached, returns the version of the cache.
-  // If not cached, returns an empty string.
-  static dataFilesCachedVersion(): Promise<string> {
+  // If data files are cached, returns the llvm version & whether the cached llvm package matches with what the wasm code expects.
+  // If not cached, returns llvm version as an empty string.
+  static dataFilesCachedVersion(): Promise<[string, boolean]> {
     return WasmCompiler.wasmFetcher
       .idbCachesExists([CLANG_DATA_FILE, LLD_DATA_FILE])
       .then((cached) => {
         if (cached) {
-          return idb_get(LLVM_VERSION_METADATA_KEY).then((version) => {
-            if (version) {
-              return version;
-            }
-            // Unable to retrieve version.
-            return "(unknown)";
+          return idb_getMany([
+            LLVM_VERSION_METADATA_KEY,
+            LLVM_PACKAGE_CHECKSUM_METADATA_KEY,
+          ]).then(([version, checksum]) => {
+            return [version || "", checksum === LLVM_PACKAGE_CHECKSUM];
           });
         }
-        return "";
+        return ["", false];
       });
   }
 }

--- a/cpp/datagen/package-libs.sh
+++ b/cpp/datagen/package-libs.sh
@@ -50,5 +50,8 @@ printf "export const LLVM_LIB_FILES = [\n" >> $CONSTANTS_FILENAME
 printf "  \"/lib/%s\",\n" "${LLVM_LIB_NAMES[@]}" >> $CONSTANTS_FILENAME
 printf "];\n\n" >> $CONSTANTS_FILENAME
 
+LLVM_PACKAGE_CHECKSUM=$(sha256sum -b onlyincludes.data onlyincludes.js onlylibs.data onlylibs.js | sha256sum | cut -f 1 -d ' ')
+printf "export const LLVM_PACKAGE_CHECKSUM = \"$LLVM_PACKAGE_CHECKSUM\";\n\n" >> $CONSTANTS_FILENAME
+
 # Cleanup
 rm -r tmp

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -102,7 +102,9 @@ const Home: NextPage = () => {
   }
 
   function downloadCompilerEnvironment(): Promise<boolean> {
-    logEvent("EnvDownloadStart");
+    logEvent("EnvDownloadStart", {
+      props: { isUpdate: !!compilerEnvironmentVersion },
+    });
     return WasmCompiler.initialize().then((success) => {
       logEvent("EnvDownloadDone", { props: { success: success } });
       if (!success) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,7 @@ import {
 } from "../components/Presets/PresetFactory";
 
 import LabeledEditor from "../components/UI/labeledEditor";
-import NavBar from "../components/UI/navbar";
+import NavBar, { LocalEnvironmentCachingStatus } from "../components/UI/navbar";
 import WasmCompiler from "../components/WasmCompiler";
 import { AllPlaygroundEvents } from "../components/Utils/Events";
 import { RunStatus } from "../components/Utils/RunStatus";
@@ -76,8 +76,9 @@ const Home: NextPage = () => {
   /* Compiler Environment Management */
   const [compilerEnvironmentVersion, setCompilerEnvironmentVersion] =
     useState("");
-  const [compilerEnvironmentStatus, setCompilerEnvironmentStatus] =
-    useState("Pending");
+  const [compilerEnvironmentStatus, setCompilerEnvironmentStatus] = useState(
+    LocalEnvironmentCachingStatus.PENDING
+  );
   const [compilerEnvironmentPopoverOpen, setCompilerEnvironmentPopoverOpen] =
     useState(false);
   const [runStatus, setRunStatus] = useState("");
@@ -89,7 +90,11 @@ const Home: NextPage = () => {
       ([version, isCompatible]) => {
         setCompilerEnvironmentVersion(version);
         setCompilerEnvironmentStatus(
-          version ? (isCompatible ? "Ready" : "Outdated") : "Pending"
+          version
+            ? isCompatible
+              ? LocalEnvironmentCachingStatus.READY
+              : LocalEnvironmentCachingStatus.OUTDATED
+            : LocalEnvironmentCachingStatus.PENDING
         );
         return !!version && isCompatible;
       }


### PR DESCRIPTION
To account for the compiler runtime getting out of sync with the cached compiler packages, keep track of the exact version of the environment (using a hash of the generated data and js files) that the runtime supports, and prompts the user to upgrade if their local version is incompatible.