### PR TITLE
Warn if "Generated" file is empty in the DRR preset

### DIFF
--- a/components/Presets/TableGen.ts
+++ b/components/Presets/TableGen.ts
@@ -106,6 +106,14 @@ export class TableGen extends CppPattern {
     printer: (text: string) => void,
     statusListener: RunStatusListener
   ): Promise<string> {
+    // Report error if user provided an empty "generated.h" file.
+    // This is likely not what they had intended.
+    if (code[1].trim().length == 0) {
+      return Promise.reject(
+        "'Generated' file is empty. Please run 'Generate Rewriters' first."
+      );
+    }
+
     let allSources: Record<string, string> = {};
     allSources["generated.h"] = code[1];
     allSources["driver.cpp"] = code[2];


### PR DESCRIPTION
First time users may be lost if they try to hit "Run" before generating rewriters. This adds an additional check for an empty "generated" file, which is likely not what the user intended. This gives up a bit of freedom for more user-friendliness. Any user wanting to not use DRR can still use the old C++ presets, so there is no loss in functionality.