### PR TITLE
Use local wasm-gen in static releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           echo "NODE_ENV=production" >> $GITHUB_ENV
           echo "PRODUCTION_DOMAIN=playground.mlir-china.org" >> $GITHUB_ENV
+          echo "SHARE_LINK_GENERATOR=https://playground.mlir-china.org/api/createShareLink" >> $GITHUB_ENV
 
       - name: Run npm build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+      
+      - name: Configure Node version
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
 
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -50,12 +55,11 @@ jobs:
       - name: Install npm dependencies
         run: npm install
 
-      - name: Set build environment
+      - name: Set static production build environment
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           echo "NODE_ENV=production" >> $GITHUB_ENV
           echo "PRODUCTION_DOMAIN=playground.mlir-china.org" >> $GITHUB_ENV
-          echo "WASM_GEN_PREFIX=https://static.playground.mlir-china.org/" >> $GITHUB_ENV
 
       - name: Run npm build
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: Release
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   release-mlir-playground:
@@ -82,9 +83,9 @@ jobs:
           tar cvzf ../${STATIC_SITE_PATH} .
           echo "STATIC_SITE_PATH=${STATIC_SITE_PATH}" >> $GITHUB_ENV
 
-      - name: Release the static site
-        uses: softprops/action-gh-release@v1
-        with:
-          files: ${{ env.STATIC_SITE_PATH }}
-          tag_name: ${{ env.NEXT_TAG }}
-          body: "This release contains a static website without any server side logic. Can be hosted using any web server that serves static content."
+      # - name: Release the static site
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     files: ${{ env.STATIC_SITE_PATH }}
+      #     tag_name: ${{ env.NEXT_TAG }}
+      #     body: "This release contains a static website without any server side logic. Can be hosted using any web server that serves static content."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   release-mlir-playground:
@@ -83,9 +82,9 @@ jobs:
           tar cvzf ../${STATIC_SITE_PATH} .
           echo "STATIC_SITE_PATH=${STATIC_SITE_PATH}" >> $GITHUB_ENV
 
-      # - name: Release the static site
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     files: ${{ env.STATIC_SITE_PATH }}
-      #     tag_name: ${{ env.NEXT_TAG }}
-      #     body: "This release contains a static website without any server side logic. Can be hosted using any web server that serves static content."
+      - name: Release the static site
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.STATIC_SITE_PATH }}
+          tag_name: ${{ env.NEXT_TAG }}
+          body: "This release contains a static website without any server side logic. Can be hosted using any web server that serves static content."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       NODE_OPTIONS: "--max_old_space_size=4096"
 
     steps:
-      # Build new Docker image if needed
+      # Set up environment
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@v1.0
         with:
@@ -27,6 +27,14 @@ jobs:
         with:
           node-version: '18.x'
 
+      # Get the version number to tag with
+      - name: Find current version number
+        run: echo "NEXT_TAG=mlir-playground-static-$(jq -r .version package.json)" >> $GITHUB_ENV
+
+      - name: Ensure current version is not already tagged
+        run: test -z $(git tag -l ${{ env.NEXT_TAG }})
+
+      # Prepare website build
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -67,14 +75,6 @@ jobs:
       - name: Export static website
         run: npx next export
 
-      - name: Bump version and push tag
-        id: version-tag
-        uses: anothrNick/github-tag-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_BRANCHES: "main"
-          DEFAULT_BUMP: "patch"
-
       - name: Package the mlir-playground static site
         run: |
           STATIC_SITE_PATH=mlir-playground-static.tar.gz
@@ -86,5 +86,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: ${{ env.STATIC_SITE_PATH }}
-          tag_name: mlir-playground-static-${{ steps.version-tag.outputs.new_tag }}
+          tag_name: ${{ env.NEXT_TAG }}
           body: "This release contains a static website without any server side logic. Can be hosted using any web server that serves static content."

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Play with [MLIR](https://mlir.llvm.org/) directly in your browser.
 
 Try it out now at our production site: [MLIR Playground](https://playground.mlir-china.org/).
 
-![Screenshot](https://user-images.githubusercontent.com/3676913/215291044-c3939310-fe02-4f10-9061-81b72f06e1f1.png)
+![Screenshot](https://user-images.githubusercontent.com/3676913/215291123-5b3d2ca3-5560-44db-be55-2d19ec9e23f7.png)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ PRs and suggestions are all warmly welcomed. At the end of the day, it's all abo
 
 ## Contributing
 
-[![Build and Deploy](https://github.com/MLIR-China/mlir-playground/actions/workflows/build-and-deploy.yml/badge.svg?branch=main)](https://github.com/MLIR-China/mlir-playground/actions/workflows/build-and-deploy.yml)
-
 ### Running Locally
 
 1. Clone this repo.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Play with [MLIR](https://mlir.llvm.org/) directly in your browser.
 
 Try it out now at our production site: [MLIR Playground](https://playground.mlir-china.org/).
 
-![Screenshot](https://user-images.githubusercontent.com/3676913/190872831-ec97d68f-31df-4058-974c-90bfc0b2d1bc.png)
+![Screenshot](https://user-images.githubusercontent.com/3676913/215291044-c3939310-fe02-4f10-9061-81b72f06e1f1.png)
 
 ## Features
 


### PR DESCRIPTION
- Instead of pointing to the hosted version, point to the local wasm-gen to maintain compatibility as the hosted version evolves. 
- Use hosted version of share link generator.
- Minor doc updates.

![Updated Screenshot](https://user-images.githubusercontent.com/3676913/215291123-5b3d2ca3-5560-44db-be55-2d19ec9e23f7.png)
